### PR TITLE
Fix typo in composite definition.

### DIFF
--- a/experiments/global_pruning.py
+++ b/experiments/global_pruning.py
@@ -132,7 +132,7 @@ def start(
             configs["model_architecture"], suggested_composite
         )
     else:
-        composite - get_cnn_composite(
+        composite = get_cnn_composite(
             configs["model_architecture"], suggested_composite
         )
 


### PR DESCRIPTION
This pull request corrects a typo in `experiments/global_pruning.py`. 
